### PR TITLE
feat: show real error text in alert

### DIFF
--- a/src/components/UI/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/UI/ConfirmModal/ConfirmModal.tsx
@@ -5,8 +5,8 @@ import Button from '@mui/material/Button';
 import { ModalWindow } from '../ModalWindow';
 
 import { useStoreDispatch } from 'hooks/store.hooks';
-import { setAlert } from 'store/uiSlice';
-import { NotifierText, NotifierType } from 'types/NotifierTypes';
+import { alertSuccess, alertError } from 'store/uiSlice';
+import { getErrorMessage } from 'utils/helpers';
 
 interface ConfirmModalProps {
   isOpen: boolean;
@@ -35,10 +35,10 @@ export const ConfirmModal = ({ isOpen, onAction, onClose }: ConfirmModalProps) =
   const runOnAction = async () => {
     try {
       await onAction();
-      dispatch(setAlert({ type: NotifierType.SUCCESS, text: NotifierText.SUCCESS }));
+      dispatch(alertSuccess());
       onClose();
     } catch (err) {
-      dispatch(setAlert({ type: NotifierType.ERROR, text: NotifierText.ERROR }));
+      dispatch(alertError(getErrorMessage(err)));
     }
   };
 

--- a/src/i18n/ru/t.json
+++ b/src/i18n/ru/t.json
@@ -39,7 +39,7 @@
   "Description": "Описание",
   "This field is required": "Это обязательное поле",
   "Success": "Выполнено успешно",
-  "Are you sure?": "Вы уверенны?",
+  "Are you sure?": "Вы уверены?",
   "Back to main": "Вернуться на главную",
   "Add first column": "Добавить первую колонку",
   "Add task": "Добавить задачу",

--- a/src/store/uiSlice.ts
+++ b/src/store/uiSlice.ts
@@ -1,5 +1,6 @@
-import { createSlice, Middleware } from '@reduxjs/toolkit';
+import { createSlice, Middleware, PayloadAction } from '@reduxjs/toolkit';
 import { IStoreState } from 'types';
+import { NotifierText, NotifierType } from 'types/NotifierTypes';
 
 const alert = {
   type: 'success',
@@ -17,11 +18,27 @@ const uiSlice = createSlice({
     return st;
   },
   reducers: {
-    setLang: (state, action) => {
-      state.lang = action.payload;
+    setLang: (state, { payload }) => {
+      state.lang = payload;
     },
-    setAlert: (state, action) => {
-      state.alert = { ...action.payload, open: true };
+    alertError: (state, action: PayloadAction<string | undefined>) => {
+      state.alert = {
+        type: NotifierType.ERROR,
+        text: action.payload
+          ? NotifierText.ERROR_PREFIX + ': ' + action.payload
+          : NotifierText.ERROR,
+        open: true,
+      };
+    },
+    alertSuccess: (state, action: PayloadAction<string | undefined>) => {
+      state.alert = {
+        type: NotifierType.SUCCESS,
+        text: action.payload ? action.payload : NotifierText.SUCCESS,
+        open: true,
+      };
+    },
+    setAlert: (state, { payload }) => {
+      state.alert = { ...payload, open: true };
     },
     clearAlert: (state) => {
       state.alert = { ...alert };
@@ -36,6 +53,6 @@ export const uiMiddleware: Middleware = (store) => (next) => (action) => {
 };
 
 export default uiSlice.reducer;
-export const { setLang, setAlert, clearAlert } = uiSlice.actions;
+export const { setLang, setAlert, alertError, alertSuccess, clearAlert } = uiSlice.actions;
 export const selectLang = (state: IStoreState) => state.ui.lang;
 export const selectAlert = (state: IStoreState) => state.ui.alert;

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,10 @@ export interface IApiError {
   };
 }
 
+export type TAnyError = Error | IApiError;
+
 export interface IApiResult<T> {
   data?: T;
   error?: IApiError;
 }
+

--- a/src/types/NotifierTypes.ts
+++ b/src/types/NotifierTypes.ts
@@ -6,4 +6,5 @@ export enum NotifierType {
 export enum NotifierText {
   SUCCESS = 'Success',
   ERROR = 'Something went wrong',
+  ERROR_PREFIX = 'Error',
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { Constants } from 'utils';
-import { TErr } from 'types';
+import { TErr, IApiError } from 'types';
 import i18next from 'i18next';
 
 export const isErrCheck = (err: TErr) => Object.values(err).some((err) => err.length > 0);
@@ -36,4 +36,10 @@ export const setCreateTitleError = (len: string): string => {
   } else {
     return ' ';
   }
+};
+
+export const getErrorMessage = (err: unknown): string => {
+  if ((err as IApiError).data?.message) return (err as IApiError).data?.message;
+  if ((err as Error).message) return (err as Error).message;
+  return '';
 };


### PR DESCRIPTION
add helpers/getErrorMessage

![изображение](https://user-images.githubusercontent.com/6938544/202044367-4b8d6b9e-7dda-4b11-b46b-7d205a58f5f8.png)

also added actions for success and error alerts. usage example:
```
    try {
      await onAction();
      dispatch(alertSuccess());
      onClose();
    } catch (err) {
      dispatch(alertError(getErrorMessage(err)));
    }
```
getErrorMessage in helper function to extract message from ApiError or just an JS Error